### PR TITLE
Catching an exception to be thrown from a background thread

### DIFF
--- a/src/ConsoleTestApp/ConsoleTestApp.csproj
+++ b/src/ConsoleTestApp/ConsoleTestApp.csproj
@@ -56,6 +56,10 @@
       <Project>{B2F31D08-C115-451D-BAD2-F56F2148143B}</Project>
       <Name>Salient.ReliableHttpClient.Serializer.Newtonsoft</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Salient.ReliableHttpClient.UnitTests\Salient.ReliableHttpClient.UnitTests.csproj">
+      <Project>{91B276EB-D5E6-40AF-9FA0-DF956489AF87}</Project>
+      <Name>Salient.ReliableHttpClient.UnitTests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Salient.ReliableHttpClient\Salient.ReliableHttpClient.csproj">
       <Project>{528B283F-41C8-489D-A031-C9A4058BB283}</Project>
       <Name>Salient.ReliableHttpClient</Name>

--- a/src/ConsoleTestApp/Program.cs
+++ b/src/ConsoleTestApp/Program.cs
@@ -5,7 +5,8 @@ using System.Text;
 using System.Threading;
 using Salient.ReliableHttpClient;
 using Salient.ReliableHttpClient.Serialization.Newtonsoft;
- 
+using Salient.ReliableHttpClient.UnitTests;
+
 
 namespace ConsoleTestApp
 {
@@ -13,32 +14,65 @@ namespace ConsoleTestApp
     {
         static void Main(string[] args)
         {
+          //NB!  DO NOT run this via Visual Studio.  You must compile the app and run it
+          //from a command prompt
+
+           SimulateHttpRequestTimeout();
+           //SimulateExceptionFromBackgroundThread();
+        }
+
+        private static void SimulateExceptionFromBackgroundThread()
+        {
+            var abortAfterMs = 500;
+            var client = new AbortingHttpClient();
+
+            try
+            {
+                client.TriggerAbortFromBackgroundProcessingThread(abortAfterMs);
+
+                Thread.Sleep(abortAfterMs * 10);
+                Console.WriteLine("If exception was caught, should never get here");
+            }
+            catch (Exception backgroundException)
+            {
+                Console.WriteLine("Trapped exception from background thread: {0}", backgroundException);
+            }
+
+            Console.WriteLine("Successfully trapped background exception");
+            Console.WriteLine("\r\nPress enter....");
+            Console.ReadLine();
+        }
+
+        private static void SimulateHttpRequestTimeout()
+        {
             var gate = new AutoResetEvent(false);
             var testWeb = "Http://localhost:21266";
             var client = new ClientBase(new Serializer());
 
             client.BeginRequest(RequestMethod.GET, testWeb, "/DelayHandler.ashx", null, null, ContentType.TEXT, ContentType.TEXT,
-                TimeSpan.FromSeconds(1), 3000, 0, ar =>
-                {
-                    Console.WriteLine("we are in the callback about to end the request");
+                                TimeSpan.FromSeconds(1), 3000, 0, ar =>
+                                    {
+                                        Console.WriteLine("we are in the callback about to end the request");
 
-                    // any time your code utilizes network resources you need to be ready to handle exceptions.
+                                        // any time your code utilizes network resources you need to be ready to handle exceptions.
 
-                    try
-                    {
-                        var response = client.EndRequest(ar);
+                                        try
+                                        {
+                                            var response = client.EndRequest(ar);
 
-                        Console.WriteLine("you will not see this line output, exception had already been triggered by .EndRequest()");
-                    }
-                    catch (Salient.ReliableHttpClient.TimeoutException ex)
-                    {
-
-                        Console.Write("our code properly caught a timeout exception:\r\n" + ex.ToString());
-                    }
-
-                    gate.Set();
-
-                }, null);
+                                            Console.WriteLine(
+                                                "you will not see this line output, exception had already been triggered by .EndRequest()");
+                                        }
+                                        catch (Salient.ReliableHttpClient.TimeoutException ex)
+                                        {
+                                            Console.Write("our code properly caught a timeout exception:\r\n" + ex.ToString());
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Console.Write("our code properly caught an exception:\r\n" + ex.ToString());
+                                        }
+                                        gate.Set();
+                                    }, null);
 
 
             gate.WaitOne(20000);

--- a/src/Salient.ReliableHttpClient.UnitTests/AbortingHttpClient.cs
+++ b/src/Salient.ReliableHttpClient.UnitTests/AbortingHttpClient.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+
+namespace Salient.ReliableHttpClient.UnitTests
+{
+    public class AbortingHttpClient
+    {
+        public void TriggerAbortFromBackgroundProcessingThread(int timeoutAfterMs)
+        {
+            new Thread(() =>
+                {
+                    try
+                    {
+                        Thread.Sleep(timeoutAfterMs);
+                        throw new WebException("Simulated exception from a BackgroundProcessing Thread");
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ReliableHttpException(ex);
+                    }
+                }).Start();
+
+            Thread.Sleep(timeoutAfterMs+100);
+        }
+
+        /// <summary>
+        /// <see cref="Salient.ReliableHttpClient.RequestController.ProcessQueue"/>
+        /// </summary>
+        public void TriggerAbort(int timeoutAfterMs)
+        {
+            var request = System.Net.WebRequest.Create("http://127.0.0.1");
+            request.Timeout = timeoutAfterMs;
+            try
+            {
+                var gate = new ManualResetEvent(false);
+                IAsyncResult webRequestAsyncResult = request.BeginGetResponse(ar =>
+                    {
+                        //Log.Info(string.Format("Received #{0} : {1} ", request.Index, request.Uri));
+                        Console.WriteLine("Async requesting {0}", request.RequestUri);
+
+                        // let's try to complete the request
+                        //_outstandingRequests--;
+
+                        Console.WriteLine("Simulating a timeout occuring...");
+                        Thread.Sleep(request.Timeout * 2);
+
+                        gate.Set();
+
+                        try
+                        {
+                            //request.CompleteRequest(ar);
+                            request.EndGetResponse(ar);
+                        }
+                        catch (Exception ex)
+                        {
+                            // the only time an exception will come out of CompleteRequest is if the request wants to be retried
+//                        request.AttemptedRetries++;
+//                        request.Watch.Reset();
+//                        request.Watch.Start();
+//                        Log.Warn(string.Format("retrying request {3} {0}\r\nattempt #{1}\r\nerror:{2} \r\nrequest:\r\n{4}",
+//                            request.Id, request.AttemptedRetries, ex.Message, request.Index, request.ToString()));
+//                        // create a new httprequest for this guy
+//                        request.BuildRequest(_requestFactory);
+//                        //put it back in the queue. if it belongs in the cache it is already there.
+//                        RequestQueue.Enqueue(request);
+                        }
+                    }, null);
+
+                new Thread(() =>
+                    {
+                        if (!gate.WaitOne(request.Timeout))
+                        {
+//                            // #TODO: disassociate the HttpWebRequest from the result, abort it, complete the result with a timeout exception
+//                            Log.Error(string.Format("Aborting #{0} : {1} because it has exceeded timeout {2}",
+//                                                    request.Index, request.Request.RequestUri, request.Timeout));
+//                            request.Request.Abort();
+
+                            Console.WriteLine("Aborting request after timeout");
+                            request.Abort();
+                            throw new WebException("Simulated exception from request.Abort");
+                        }
+                    }).Start();
+
+                // #TODO: timeouts do not apply to async HttpWebRequests so we need to implement this ourselves
+
+                //EnsureRequestWillAbortAfterTimeout(request, webRequestAsyncResult);
+
+//                Log.Info(string.Format("Dispatched #{0} : {1} ", request.Index, request.Uri));
+            }
+            catch (Exception ex)
+            {
+//                string message = string.Format("Error dispatching #{0} : {1} \r\n{2} \r\n{3}", request.Index,
+//                                               request.Uri, ex.Message, request.ToString());
+//                Log.Error(message);
+                Console.WriteLine(ex.ToString());
+
+                string message = "Error dispatching";
+                ReliableHttpException ex2 = ReliableHttpException.Create(message, ex);
+                throw ex2;
+            }
+            finally
+            {
+//                RequestQueue.Dequeue();
+//                _outstandingRequests++;
+                // TODO: should this really be here if there was an error that prevented dispatch?
+            }
+        }
+
+    }
+}

--- a/src/Salient.ReliableHttpClient.UnitTests/RequestAbortFixture.cs
+++ b/src/Salient.ReliableHttpClient.UnitTests/RequestAbortFixture.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using NUnit.Framework;
 
 namespace Salient.ReliableHttpClient.UnitTests
@@ -20,93 +15,6 @@ namespace Salient.ReliableHttpClient.UnitTests
 
             Thread.Sleep(abortAfterMs * 10);
         }
-    }
-
-    public class AbortingHttpClient
-    {
-        /// <summary>
-        /// <see cref="Salient.ReliableHttpClient.RequestController.ProcessQueue"/>
-        /// </summary>
-        public void TriggerAbort(int timeoutAfterMs)
-        {
-            var request = System.Net.WebRequest.Create("http://127.0.0.1");
-            request.Timeout = timeoutAfterMs;
-            try
-            {
-                var gate = new ManualResetEvent(false);
-                IAsyncResult webRequestAsyncResult = request.BeginGetResponse(ar =>
-                {
-                    //Log.Info(string.Format("Received #{0} : {1} ", request.Index, request.Uri));
-                    Console.WriteLine("Async requesting {0}", request.RequestUri);
-
-                    // let's try to complete the request
-                    //_outstandingRequests--;
-
-                    Console.WriteLine("Simulating a timeout occuring...");
-                    Thread.Sleep(request.Timeout * 2);
-
-                    gate.Set();
-
-                    try
-                    {
-                        //request.CompleteRequest(ar);
-                        request.EndGetResponse(ar);
-                    }
-                    catch (Exception ex)
-                    {
-                        // the only time an exception will come out of CompleteRequest is if the request wants to be retried
-//                        request.AttemptedRetries++;
-//                        request.Watch.Reset();
-//                        request.Watch.Start();
-//                        Log.Warn(string.Format("retrying request {3} {0}\r\nattempt #{1}\r\nerror:{2} \r\nrequest:\r\n{4}",
-//                            request.Id, request.AttemptedRetries, ex.Message, request.Index, request.ToString()));
-//                        // create a new httprequest for this guy
-//                        request.BuildRequest(_requestFactory);
-//                        //put it back in the queue. if it belongs in the cache it is already there.
-//                        RequestQueue.Enqueue(request);
-                    }
-                }, null);
-
-                new Thread(() =>
-                    {
-                        if (!gate.WaitOne(request.Timeout))
-                        {
-//                            // #TODO: disassociate the HttpWebRequest from the result, abort it, complete the result with a timeout exception
-//                            Log.Error(string.Format("Aborting #{0} : {1} because it has exceeded timeout {2}",
-//                                                    request.Index, request.Request.RequestUri, request.Timeout));
-//                            request.Request.Abort();
-
-                            Console.WriteLine("Aborting request after timeout");
-                            request.Abort();
-                            throw new WebException("Simulated exception from request.Abort");
-                        }
-                    }).Start();
-
-                // #TODO: timeouts do not apply to async HttpWebRequests so we need to implement this ourselves
-
-                //EnsureRequestWillAbortAfterTimeout(request, webRequestAsyncResult);
-
-//                Log.Info(string.Format("Dispatched #{0} : {1} ", request.Index, request.Uri));
-            }
-            catch (Exception ex)
-            {
-//                string message = string.Format("Error dispatching #{0} : {1} \r\n{2} \r\n{3}", request.Index,
-//                                               request.Uri, ex.Message, request.ToString());
-//                Log.Error(message);
-                Console.WriteLine(ex.ToString());
-
-                string message = "Error dispatching";
-                ReliableHttpException ex2 = ReliableHttpException.Create(message, ex);
-                throw ex2;
-            }
-            finally
-            {
-//                RequestQueue.Dequeue();
-//                _outstandingRequests++;
-                // TODO: should this really be here if there was an error that prevented dispatch?
-            }
-        }
-
     }
 }
 

--- a/src/Salient.ReliableHttpClient.UnitTests/Salient.ReliableHttpClient.UnitTests.csproj
+++ b/src/Salient.ReliableHttpClient.UnitTests/Salient.ReliableHttpClient.UnitTests.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbortingHttpClient.cs" />
     <Compile Include="implementation\SampleClient.cs" />
     <Compile Include="implementation\TestClass.cs" />
     <Compile Include="PrerequisiteFixture.cs" />

--- a/src/Salient.ReliableHttpClient.sln
+++ b/src/Salient.ReliableHttpClient.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{389A1397-23E3-4B4B-B8CA-54E8B7A39451}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.exe = .nuget\NuGet.exe

--- a/src/Salient.ReliableHttpClient/RequestController.cs
+++ b/src/Salient.ReliableHttpClient/RequestController.cs
@@ -232,6 +232,9 @@ namespace Salient.ReliableHttpClient
 
                         new Thread(() =>
                                        {
+                                           Console.WriteLine("About to simulate request.abort exception happening");
+                                           throw new System.Net.WebException("Simulating request.abort exception happening");
+
                                            if (!gate.WaitOne(request.Timeout))
                                            {
                                                // #TODO: disassociate the HttpWebRequest from the result, abort it, complete the result with a timeout exception

--- a/src/TestWeb/TestWeb.csproj
+++ b/src/TestWeb/TestWeb.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,11 @@
     <AssemblyName>TestWeb</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -68,8 +74,13 @@
   <ItemGroup>
     <Content Include="DelayHandler.ashx" />
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">


### PR DESCRIPTION
As far as I can tell, this sample demonstrates that in the unlikely event that Request.Abort does throw an exception, it isn't possible to actually catch it in the calling code.
